### PR TITLE
#152919352 Exercise Info Endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,6 +59,9 @@ target/
 # IDE
 .idea/
 
-# External Libraries 
+# External Libraries
 wger/core/static/bower_components
 node_modules
+
+.DS_Store
+wger/.DS_Store

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,6 @@ install:
   # Install requirements
   - pip install -r requirements_devel.txt
   - npm install
-  - npm install gulp-cli
   - if [[ "$DB" = "postgresql" ]]; then pip install psycopg2; fi
 
   # Setup application

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,6 +40,7 @@ install:
   # Install requirements
   - pip install -r requirements_devel.txt
   - npm install
+  - npm install gulp-cli
   - if [[ "$DB" = "postgresql" ]]; then pip install psycopg2; fi
 
   # Setup application

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,13 @@
+{
+  "name": "wger",
+  "version": "1.8.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "bower": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/bower/-/bower-1.8.2.tgz",
+      "integrity": "sha1-rfU1KcjUrwLvJPuNU0HBQZ0z4vc="
+    }
+  }
+}

--- a/wger/exercises/api/serializers.py
+++ b/wger/exercises/api/serializers.py
@@ -57,6 +57,15 @@ class ExerciseImageSerializer(serializers.ModelSerializer):
         model = ExerciseImage
 
 
+class ExerciseInfoSerializer(serializers.ModelSerializer):
+    """
+    ExerciseInfo serializer
+    """
+    class Meta:
+        model = Exercise
+        depth = 1
+
+
 class ExerciseCommentSerializer(serializers.ModelSerializer):
     '''
     ExerciseComment serializer

--- a/wger/exercises/api/views.py
+++ b/wger/exercises/api/views.py
@@ -229,4 +229,3 @@ class ExerciseInfoView(viewsets.ModelViewSet):
                      'equipment',
                      'license',
                      'license_author')
-

--- a/wger/exercises/api/views.py
+++ b/wger/exercises/api/views.py
@@ -32,7 +32,8 @@ from wger.exercises.api.serializers import (
     ExerciseImageSerializer,
     ExerciseCategorySerializer,
     EquipmentSerializer,
-    ExerciseCommentSerializer
+    ExerciseCommentSerializer,
+    ExerciseInfoSerializer
 )
 from wger.exercises.models import (
     Exercise,
@@ -207,3 +208,25 @@ class MuscleViewSet(viewsets.ReadOnlyModelViewSet):
     ordering_fields = '__all__'
     filter_fields = ('name',
                      'is_front')
+
+
+class ExerciseInfoView(viewsets.ModelViewSet):
+    """
+    API endpoint for exercise info
+    """
+    queryset = Exercise.objects.all()
+    serializer_class = ExerciseInfoSerializer
+    permission_classes = (IsAuthenticatedOrReadOnly, CreateOnlyPermission)
+    ordering_fields = '__all__'
+    filter_fields = ('category',
+                     'creation_date',
+                     'description',
+                     'language',
+                     'muscles',
+                     'muscles_secondary',
+                     'status',
+                     'name',
+                     'equipment',
+                     'license',
+                     'license_author')
+

--- a/wger/exercises/tests/test_exercise_info.py
+++ b/wger/exercises/tests/test_exercise_info.py
@@ -1,5 +1,6 @@
 from wger.core.tests.base_testcase import WorkoutManagerTestCase
 
+
 class ExerciseInfoTestCase(WorkoutManagerTestCase):
     '''
     Test the Exercise Info endpoint

--- a/wger/exercises/tests/test_exercise_info.py
+++ b/wger/exercises/tests/test_exercise_info.py
@@ -1,0 +1,32 @@
+from wger.core.tests.base_testcase import WorkoutManagerTestCase
+
+class ExerciseInfoTestCase(WorkoutManagerTestCase):
+    '''
+    Test the Exercise Info endpoint
+    '''
+
+    def test_exercise_info_endpoint(self):
+        '''
+        Test that the endpoint returns all exercise infomation
+        '''
+        endpoint = "/api/v2/exerciseinfo/"
+
+        resp = self.client.get(endpoint)
+
+        self.assertEqual(resp.status_code, 200)
+
+        self.assertIn("license_author", str(resp.data))
+
+        self.assertIn("uuid", str(resp.data))
+
+        self.assertIn("license", str(resp.data))
+
+        self.assertIn("category", str(resp.data))
+
+        self.assertIn("language", str(resp.data))
+
+        self.assertIn("muscles", str(resp.data))
+
+        self.assertIn("muscles_secondary", str(resp.data))
+
+        self.assertIn("equipment", str(resp.data))

--- a/wger/urls.py
+++ b/wger/urls.py
@@ -105,6 +105,7 @@ router.register(r'setting-weightunit', core_api_views.WeightUnitViewSet, base_na
 router.register(r'exercise', exercises_api_views.ExerciseViewSet, base_name='exercise')
 router.register(r'equipment', exercises_api_views.EquipmentViewSet, base_name='api')
 router.register(r'exercisecategory', exercises_api_views.ExerciseCategoryViewSet, base_name='exercisecategory')
+router.register(r'exerciseinfo', exercises_api_views.ExerciseInfoView, base_name='exerciseinfo')
 router.register(r'exerciseimage', exercises_api_views.ExerciseImageViewSet, base_name='exerciseimage')
 router.register(r'exercisecomment', exercises_api_views.ExerciseCommentViewSet, base_name='exercisecomment')
 router.register(r'muscle', exercises_api_views.MuscleViewSet, base_name='muscle')


### PR DESCRIPTION
#### What does this PR do

Creates an endpoint in the API for viewing all information related an exercise.

#### Description of the task to be completed

There should be a new read-only API endpoint that collects all the information of an exercise such as muscles, category, images, etc. This makes it easier for clients to get all the infos since only a single request is needed to be done

#### How should this manually be tested?

After running the server with
>python manage.py runserver

, one can navigate to the following endpoint to see the results:
>http://localhost:8000/api/v2/exerciseinfo/

#### Any background context you want to provide?

#### Pivotal Tracker story

See [Feature #152919352](https://www.pivotaltracker.com/story/show/152919352)

#### Screenshots

<img width="595" alt="screen shot 2017-11-22 at 16 05 57" src="https://user-images.githubusercontent.com/31339738/33128902-31b9e450-cf9f-11e7-9b43-e13b5c8afa3f.png">

#### Questions