### PR TITLE
#152919354 Fitbit Support Logic Bug.

### DIFF
--- a/wger/core/views/user.py
+++ b/wger/core/views/user.py
@@ -384,7 +384,10 @@ def fitbit_data_sync(request, code=None):
                         entry.user = request.user
                         entry.date = datetime.datetime.strptime(
                             w['date'], '%Y-%m-%d')
-                        entry.save()
+                        try:
+                            entry.save()
+                        except Exception:
+                            pass
 
                     messages.success(request, _(
                         'Successfully synced weight data.'))


### PR DESCRIPTION
#### What does this PR do

Fixes a bug in the Fitbit integration logic.

#### Description of the task to be completed

The user was only able to sync their fitbit data once and if they added more data to fitbit, they would not be able to sync the data again.

#### How should this manually be tested?

* Log in to your wger account
* Click on the `Weight` dropdown link and click on the `Weight Overview` link
* Click on the `Options` button link and choose `Import from Fitbit`
* Click on the `Grant Wger Access To Your Fitbit Data` button
* Log in to your Fitbit account
* Click on `Allow` to grant access to Fitbit
* Navigate back to `Weight Overview` to see the synced data

#### Any background context you want to provide?

#### Pivotal Tracker story

See [Feature #152919354](https://www.pivotaltracker.com/story/show/152919354)

#### Screenshots

<img width="1358" alt="screen shot 2017-12-08 at 12 46 25" src="https://user-images.githubusercontent.com/31339738/33760886-60239e50-dc18-11e7-8f24-d87b828563dd.png">
<img width="1358" alt="screen shot 2017-12-08 at 12 46 53" src="https://user-images.githubusercontent.com/31339738/33760905-6d53e42c-dc18-11e7-9838-1ecc738d62a2.png">
<img width="1357" alt="screen shot 2017-12-08 at 12 47 58" src="https://user-images.githubusercontent.com/31339738/33760918-76717ab0-dc18-11e7-8b4f-486faeae8b65.png">
<img width="496" alt="screen shot 2017-12-08 at 12 48 17" src="https://user-images.githubusercontent.com/31339738/33760934-7e7e2d66-dc18-11e7-8b4c-02cccbae1d2d.png">

#### Questions
